### PR TITLE
Dockerfile: Improve build image process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,21 @@
 FROM debian:buster-slim
-RUN dpkg --add-architecture i386
-RUN apt-get update && apt-get install -y curl apt-transport-https gnupg
-RUN curl -o - https://dl.winehq.org/wine-builds/Release.key | apt-key add -
-RUN echo "deb https://dl.winehq.org/wine-builds/debian/ buster main" > /etc/apt/sources.list.d/winehq.list
-RUN apt-get update
-RUN apt-get -y install winehq-staging meson mingw-w64 mingw-w64-i686-dev mingw-w64-x86-64-dev
-RUN apt-get -y install build-essential unzip
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y curl apt-transport-https gnupg ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+RUN curl -o - https://dl.winehq.org/wine-builds/Release.key | apt-key add - && \
+    echo "deb https://dl.winehq.org/wine-builds/debian/ buster main" > /etc/apt/sources.list.d/winehq.list
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y winehq-staging meson mingw-w64 mingw-w64-i686-dev mingw-w64-x86-64-dev build-essential bsdtar && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN curl -L -o glslang.zip https://github.com/KhronosGroup/glslang/releases/download/7.8.2850/glslang-master-linux-Release.zip
-RUN unzip glslang.zip -d /usr
+RUN curl -L https://github.com/KhronosGroup/glslang/releases/download/7.8.2850/glslang-master-linux-Release.zip | bsdtar -xvf - -C /usr && \
+    chmod +x /usr/bin/glslangValidator
 
-RUN update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
-RUN update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
-RUN update-alternatives --set i686-w64-mingw32-gcc /usr/bin/i686-w64-mingw32-gcc-posix
-RUN update-alternatives --set i686-w64-mingw32-g++ /usr/bin/i686-w64-mingw32-g++-posix
+RUN update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix && \
+    update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix && \
+    update-alternatives --set i686-w64-mingw32-gcc /usr/bin/i686-w64-mingw32-gcc-posix && \
+    update-alternatives --set i686-w64-mingw32-g++ /usr/bin/i686-w64-mingw32-g++-posix
 
 WORKDIR /root/build
 RUN mkdir -p /root/out/dxvk-master


### PR DESCRIPTION
* Reduce the docker image build time and size:
  - Minimize layers (factorize RUN statements)
  - Don't install recommends packages (less packages to download/install)
  - Clean apt cache

* glslang zip file is not stored anymore locally because we are
extracting the content on the fly. unzip command is replaced by
bsdtar because unzip doesn't handle content with stdin.

Before:
  * apt:
      Need to get 407 MB of archives.
      After this operation, 2334 MB of additional disk space will be used.
  * image size:
      2.18GB

After:
  * apt:
      Need to get 330 MB of archives.
      After this operation, 1726 MB of additional disk space will be used.
  * image size:
      1.75GB