### PR TITLE
Dockerfile image changed to sid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:sid-slim
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
     apt-get install --no-install-recommends -y curl apt-transport-https gnupg ca-certificates && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM debian:sid-slim
+
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
     apt-get install --no-install-recommends -y curl apt-transport-https gnupg ca-certificates && \


### PR DESCRIPTION
The latest dxvk branch will not build with the build deps included in buster. Using sid allows for a successful build. 